### PR TITLE
Add support to specify the Instance Profile ARN when creating a Cluster

### DIFF
--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -65,6 +65,10 @@ func resourceDatabricksCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"instance_profile_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"ebs_volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -262,6 +266,10 @@ func resourceDatabricksClusterExpandAwsAttributes(awsAttributes []interface{}) m
 		result.ZoneId = v.(string)
 	}
 
+	if v, ok := awsAttributesElem["instance_profile_arn"]; ok {
+		result.InstanceProfileArn = v.(string)
+	}
+
 	if v, ok := awsAttributesElem["ebs_volume_type"]; ok {
 		volumeType := models.ClustersEbsVolumeType(v.(string))
 		result.EbsVolumeType = &volumeType
@@ -283,6 +291,7 @@ func resourceDatabricksClusterFlattenAwsAttributes(awsAttributes *models.Cluster
 	if awsAttributes != nil {
 		attrs := make(map[string]interface{})
 		attrs["zone_id"] = awsAttributes.ZoneId
+		attrs["instance_profile_arn"] = awsAttributes.InstanceProfileArn
 		if awsAttributes.EbsVolumeType != nil {
 			attrs["ebs_volume_type"] = string(*awsAttributes.EbsVolumeType)
 			attrs["ebs_volume_count"] = int(awsAttributes.EbsVolumeCount)


### PR DESCRIPTION
This is to allow the Profile ARN to be specified via the terraform provider when creating the cluster.  By default, no profile is assigned to the instances.

The resource is defined as before, but with the extra option `instance_profile_arn`

```
resource "databricks_cluster" "cluster" {
    name                    = "tf-test"
    spark_version           = "4.1.x-scala2.11"
    node_type_id            = "m4.large"
    num_workers             = 1
    autotermination_minutes = 10

    aws_attributes = {
        zone_id              = "eu-west-1c"
        instance_profile_arn = "arn:aws:iam::123456789:instance-profile/data-bricks-profile"
        ebs_volume_type      = "GENERAL_PURPOSE_SSD"
        ebs_volume_count     = 1
        ebs_volume_size      = 100
    }    
}
```