### PR TITLE
Add support to specify the spark_env_vars option

### DIFF
--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -216,7 +216,7 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 		request.AwsAttributes = &awsAttributes
 	}
 
-	if d.HasChanged("spark_env_vars") {
+	if d.HasChange("spark_env_vars") {
 		v := d.Get("spark_env_vars")
 		sparkEnvVars := make(map[string]string)
 

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -89,6 +89,10 @@ func resourceDatabricksCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"spark_env_vars": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -123,6 +127,18 @@ func resourceDatabricksClusterCreate(d *schema.ResourceData, m interface{}) erro
 	if v, ok := d.GetOk("aws_attributes"); ok {
 		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(v.(*schema.Set).List())
 		request.AwsAttributes = &awsAttributes
+	}
+
+	if v, ok := d.GetOk("spark_env_vars"); ok {
+		sparkEnvVars := make(map[string]string)
+
+		for key, value := range v.(map[string]interface{}) {
+			switch value := value.(type) {
+			case string:
+				sparkEnvVars[key] = value
+			}
+		}
+		request.SparkEnvVars = sparkEnvVars
 	}
 
 	resp, err := apiClient.CreateSync(&request)
@@ -161,6 +177,7 @@ func resourceDatabricksClusterRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("autoscale", resourceDatabricksClusterFlattenAutoscale(resp.Autoscale))
 	d.Set("autotermination_minutes", resp.AutoterminationMinutes)
 	d.Set("aws_attributes", resourceDatabricksClusterFlattenAwsAttributes(resp.AwsAttributes))
+	d.Set("spark_env_vars", resp.SparkEnvVars)
 
 	return nil
 }
@@ -197,6 +214,19 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 		value := d.Get("awsAttributes").(*schema.Set).List()
 		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(value)
 		request.AwsAttributes = &awsAttributes
+	}
+
+	if d.HasChanged("spark_env_vars") {
+		v := d.Get("spark_env_vars")
+		sparkEnvVars := make(map[string]string)
+
+		for key, value := range v.(map[string]interface{}) {
+			switch value := value.(type) {
+			case string:
+				sparkEnvVars[key] = value
+			}
+		}
+		request.SparkEnvVars = sparkEnvVars
 	}
 
 	return apiClient.EditSync(&request)


### PR DESCRIPTION
Allow configuring of cluster spark environment variables, e.g.:

```
resource "databricks_cluster" "test-cluster" {
   name                    = "tf-test"
   spark_version           = "4.2.x-scala2.11"
   node_type_id            = "r3.xlarge"
   autotermination_minutes = 60

   spark_env_vars = {
     "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
     "example2" = "testing123"
   }

 }
```