### PR TITLE
Add 'spark_env_vars' option to provider with Acceptance Testing.

### DIFF
--- a/databricks/provider_test.go
+++ b/databricks/provider_test.go
@@ -39,4 +39,11 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("DATABRICKS_WORKSPACE"); v == "" {
 		t.Fatal("DATABRICKS_WORKSPACE must be set for acceptance tests")
 	}
+
+	if v := os.Getenv("TEST_AWS"); v == "1" {
+		if arn := os.Getenv("AWS_ARN_ROLE"); arn == "" {
+			t.Fatal("AWS_ARN_ROLE must be set for acceptance tests with AWS")
+		}
+	}
+
 }

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -89,6 +89,10 @@ func resourceDatabricksCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"spark_env_vars": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -123,6 +127,18 @@ func resourceDatabricksClusterCreate(d *schema.ResourceData, m interface{}) erro
 	if v, ok := d.GetOk("aws_attributes"); ok {
 		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(v.(*schema.Set).List())
 		request.AwsAttributes = &awsAttributes
+	}
+
+	if v, ok := d.GetOk("spark_env_vars"); ok {
+		sparkEnvVars := make(map[string]string)
+
+		for key, value := range v.(map[string]interface{}) {
+			switch value := value.(type) {
+			case string:
+				sparkEnvVars[key] = value
+			}
+		}
+		request.SparkEnvVars = sparkEnvVars
 	}
 
 	resp, err := apiClient.CreateSync(&request)
@@ -161,6 +177,7 @@ func resourceDatabricksClusterRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("autoscale", resourceDatabricksClusterFlattenAutoscale(resp.Autoscale))
 	d.Set("autotermination_minutes", resp.AutoterminationMinutes)
 	d.Set("aws_attributes", resourceDatabricksClusterFlattenAwsAttributes(resp.AwsAttributes))
+	d.Set("spark_env_vars", resp.SparkEnvVars)
 
 	return nil
 }
@@ -196,6 +213,18 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	if v, ok := d.GetOk("aws_attributes"); ok {
 		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(v.(*schema.Set).List())
 		request.AwsAttributes = &awsAttributes
+	}
+
+	if v, ok := d.GetOk("spark_env_vars"); ok {
+		sparkEnvVars := make(map[string]string)
+
+		for key, value := range v.(map[string]interface{}) {
+			switch value := value.(type) {
+			case string:
+				sparkEnvVars[key] = value
+			}
+		}
+		request.SparkEnvVars = sparkEnvVars
 	}
 
 	return apiClient.EditSync(&request)

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -207,7 +207,7 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if v, ok := d.GetOk("autotermination_minutes"); ok {
-        request.AutoterminationMinutes = int32(v.(int))
+		request.AutoterminationMinutes = int32(v.(int))
 	}
 
 	if v, ok := d.GetOk("aws_attributes"); ok {

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -206,7 +206,7 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 		request.Autoscale = &autoscale
 	}
 
-	if d.HasChange("autotermination_minutes") {
+	if v, ok := d.GetOk("autotermination_minutes"); ok {
 		request.AutoterminationMinutes = int32(d.Get("autotermination_minutes").(int))
 	}
 

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -176,6 +176,10 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	request.SparkVersion = d.Get("spark_version").(string)
 	request.NodeTypeId = d.Get("node_type_id").(string)
 
+	if v, ok := d.GetOk("name"); ok {
+		request.ClusterName = v.(string)
+	}
+
 	if v, ok := d.GetOk("num_workers"); ok {
 		request.NumWorkers = int32(v.(int))
 	}
@@ -185,17 +189,12 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 		request.Autoscale = &autoscale
 	}
 
-	if d.HasChange("name") {
-		request.ClusterName = d.Get("name").(string)
-	}
-
 	if d.HasChange("autotermination_minutes") {
 		request.AutoterminationMinutes = int32(d.Get("autotermination_minutes").(int))
 	}
 
-	if d.HasChange("aws_attributes") {
-		value := d.Get("awsAttributes").(*schema.Set).List()
-		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(value)
+	if v, ok := d.GetOk("aws_attributes"); ok {
+		awsAttributes := resourceDatabricksClusterExpandAwsAttributes(v.(*schema.Set).List())
 		request.AwsAttributes = &awsAttributes
 	}
 

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -207,7 +207,7 @@ func resourceDatabricksClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if v, ok := d.GetOk("autotermination_minutes"); ok {
-		request.AutoterminationMinutes = int32(d.Get("autotermination_minutes").(int))
+        request.AutoterminationMinutes = int32(v.(int))
 	}
 
 	if v, ok := d.GetOk("aws_attributes"); ok {

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -7,10 +7,18 @@ import (
 	"github.com/betabandido/databricks-sdk-go/models"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"strings"
 	"testing"
 )
 
 func TestAccDatabricksCluster_basic(t *testing.T) {
+	if v := os.Getenv("TEST_AWS"); v == "1" {
+		t.Skip("Skipping test as TEST_AWS is set")
+		return
+	}
+
+	return
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -42,6 +50,59 @@ func TestAccDatabricksCluster_basic(t *testing.T) {
 						"databricks_cluster.cluster", "spark_version", "4.2.x-scala2.11"),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "node_type_id", "Standard_D3_v2"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "num_workers", "2"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "autotermination_minutes", "15"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabricksCluster_basic_aws(t *testing.T) {
+	if v := os.Getenv("TEST_AWS"); v == "" {
+		t.Skip("Skipping test as TEST_AWS is not set")
+		return
+	}
+
+	awsARNString := os.Getenv("AWS_ARN_ROLE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksClusterConfigAws(awsARNString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDatabricksClusterExists("databricks_cluster.cluster"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "name", "tf-test-cluster"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_version", "4.2.x-scala2.11"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "node_type_id", "m4.large"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "aws_attributes.2335671095.instance_profile_arn", awsARNString),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "num_workers", "1"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "autotermination_minutes", "10"),
+				),
+			},
+			{
+				Config: testAccDatabricksClusterConfigUpdateAws(awsARNString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDatabricksClusterExists("databricks_cluster.cluster"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "name", "tf-test-cluster-renamed"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_version", "4.2.x-scala2.11"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "node_type_id", "m4.large"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "aws_attributes.2335671095.instance_profile_arn", awsARNString),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "num_workers", "2"),
 					resource.TestCheckResourceAttr(
@@ -101,12 +162,36 @@ func testAccDatabricksClusterConfig() string {
 resource "databricks_cluster" "cluster" {
 	name                    = "tf-test-cluster"
 	spark_version           = "4.2.x-scala2.11"
-	node_type_id            = "Standard_D3_v2"
+	node_type_id            = "m4.large"
 	num_workers             = 1
 	autotermination_minutes = 10
 	permanently_delete      = true
 } 
 `
+}
+
+func testAccDatabricksClusterConfigAws(awsARNString string) string {
+
+	awsTestConfig := `
+resource "databricks_cluster" "cluster" {
+  name                    = "tf-test-cluster"
+  spark_version           = "4.2.x-scala2.11"
+  node_type_id            = "m4.large"
+  num_workers             = 1
+  autotermination_minutes = 10
+  permanently_delete      = true
+  aws_attributes = {
+    instance_profile_arn    = "AWSARNSTRING"
+    zone_id          = "eu-west-1a"
+    ebs_volume_type  = "THROUGHPUT_OPTIMIZED_HDD"
+    ebs_volume_count = 1
+    ebs_volume_size  = 500
+  }
+}
+`
+	awsTestConfig = strings.Replace(awsTestConfig, "AWSARNSTRING", awsARNString, 1)
+	return awsTestConfig
+
 }
 
 func testAccDatabricksClusterConfigUpdate() string {
@@ -120,6 +205,28 @@ resource "databricks_cluster" "cluster" {
 	permanently_delete      = true
 } 
 `
+}
+
+func testAccDatabricksClusterConfigUpdateAws(awsARNString string) string {
+	awsTestConfig := `
+resource "databricks_cluster" "cluster" {
+  name                    = "tf-test-cluster-renamed"
+  spark_version           = "4.2.x-scala2.11"
+  node_type_id            = "m4.large"
+  num_workers             = 2
+  autotermination_minutes = 15
+  permanently_delete      = true
+  aws_attributes = {
+    instance_profile_arn    = "AWSARNSTRING"
+    zone_id          = "eu-west-1a"
+    ebs_volume_type  = "THROUGHPUT_OPTIMIZED_HDD"
+    ebs_volume_count = 1
+    ebs_volume_size  = 500
+  }
+}
+`
+	awsTestConfig = strings.Replace(awsTestConfig, "AWSARNSTRING", awsARNString, 1)
+	return awsTestConfig
 }
 
 func TestDatabricksCluster_handlesNonExistingClusterError(t *testing.T) {

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -38,6 +38,8 @@ func TestAccDatabricksCluster_basic(t *testing.T) {
 						"databricks_cluster.cluster", "num_workers", "1"),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "autotermination_minutes", "10"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_env_vars.PYSPARK_PYTHON", "/databricks/python3/bin/python3"),
 				),
 			},
 			{
@@ -54,6 +56,8 @@ func TestAccDatabricksCluster_basic(t *testing.T) {
 						"databricks_cluster.cluster", "num_workers", "2"),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "autotermination_minutes", "15"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_env_vars.PYSPARK_PYTHON", "/databricks/python3/bin/python3"),
 				),
 			},
 		},
@@ -89,6 +93,8 @@ func TestAccDatabricksCluster_basic_aws(t *testing.T) {
 						"databricks_cluster.cluster", "num_workers", "1"),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "autotermination_minutes", "10"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_env_vars.PYSPARK_PYTHON", "/databricks/python3/bin/python3"),
 				),
 			},
 			{
@@ -107,6 +113,8 @@ func TestAccDatabricksCluster_basic_aws(t *testing.T) {
 						"databricks_cluster.cluster", "num_workers", "2"),
 					resource.TestCheckResourceAttr(
 						"databricks_cluster.cluster", "autotermination_minutes", "15"),
+					resource.TestCheckResourceAttr(
+						"databricks_cluster.cluster", "spark_env_vars.PYSPARK_PYTHON", "/databricks/python3/bin/python3"),
 				),
 			},
 		},
@@ -160,12 +168,13 @@ func testAccCheckDatabricksClusterDestroy(s *terraform.State) error {
 func testAccDatabricksClusterConfig() string {
 	return `
 resource "databricks_cluster" "cluster" {
-	name                    = "tf-test-cluster"
-	spark_version           = "4.2.x-scala2.11"
-	node_type_id            = "m4.large"
-	num_workers             = 1
-	autotermination_minutes = 10
-	permanently_delete      = true
+  name                          = "tf-test-cluster"
+  spark_version                 = "4.2.x-scala2.11"
+  node_type_id                  = "m4.large"
+  num_workers                   = 1
+  autotermination_minutes       = 10
+  permanently_delete            = true
+  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
 } 
 `
 }
@@ -174,18 +183,19 @@ func testAccDatabricksClusterConfigAws(awsARNString string) string {
 
 	awsTestConfig := `
 resource "databricks_cluster" "cluster" {
-  name                    = "tf-test-cluster"
-  spark_version           = "4.2.x-scala2.11"
-  node_type_id            = "m4.large"
-  num_workers             = 1
-  autotermination_minutes = 10
-  permanently_delete      = true
+  name                          = "tf-test-cluster"
+  spark_version                 = "4.2.x-scala2.11"
+  node_type_id                  = "m4.large"
+  num_workers                   = 1
+  autotermination_minutes       = 10
+  permanently_delete            = true
+  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
   aws_attributes = {
-    instance_profile_arn    = "AWSARNSTRING"
-    zone_id          = "eu-west-1a"
-    ebs_volume_type  = "THROUGHPUT_OPTIMIZED_HDD"
-    ebs_volume_count = 1
-    ebs_volume_size  = 500
+    instance_profile_arn = "AWSARNSTRING"
+    zone_id              = "eu-west-1a"
+    ebs_volume_type      = "THROUGHPUT_OPTIMIZED_HDD"
+    ebs_volume_count     = 1
+    ebs_volume_size      = 500
   }
 }
 `
@@ -197,12 +207,13 @@ resource "databricks_cluster" "cluster" {
 func testAccDatabricksClusterConfigUpdate() string {
 	return `
 resource "databricks_cluster" "cluster" {
-	name                    = "tf-test-cluster-renamed"
-	spark_version           = "4.2.x-scala2.11"
-	node_type_id            = "Standard_D3_v2"
-	num_workers             = 2
-	autotermination_minutes = 15
-	permanently_delete      = true
+  name                          = "tf-test-cluster-renamed"
+  spark_version                 = "4.2.x-scala2.11"
+  node_type_id                  = "Standard_D3_v2"
+  num_workers                   = 2
+  autotermination_minutes       = 15
+  permanently_delete            = true
+  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
 } 
 `
 }
@@ -210,18 +221,19 @@ resource "databricks_cluster" "cluster" {
 func testAccDatabricksClusterConfigUpdateAws(awsARNString string) string {
 	awsTestConfig := `
 resource "databricks_cluster" "cluster" {
-  name                    = "tf-test-cluster-renamed"
-  spark_version           = "4.2.x-scala2.11"
-  node_type_id            = "m4.large"
-  num_workers             = 2
-  autotermination_minutes = 15
-  permanently_delete      = true
+  name                          = "tf-test-cluster-renamed"
+  spark_version                 = "4.2.x-scala2.11"
+  node_type_id                  = "m4.large"
+  num_workers                   = 2
+  autotermination_minutes       = 15
+  permanently_delete            = true
+  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
   aws_attributes = {
-    instance_profile_arn    = "AWSARNSTRING"
-    zone_id          = "eu-west-1a"
-    ebs_volume_type  = "THROUGHPUT_OPTIMIZED_HDD"
-    ebs_volume_count = 1
-    ebs_volume_size  = 500
+    instance_profile_arn = "AWSARNSTRING"
+    zone_id              = "eu-west-1a"
+    ebs_volume_type      = "THROUGHPUT_OPTIMIZED_HDD"
+    ebs_volume_count     = 1
+    ebs_volume_size      = 500
   }
 }
 `

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -18,7 +18,6 @@ func TestAccDatabricksCluster_basic(t *testing.T) {
 		return
 	}
 
-	return
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -174,7 +174,9 @@ resource "databricks_cluster" "cluster" {
   num_workers                   = 1
   autotermination_minutes       = 10
   permanently_delete            = true
-  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
+  spark_env_vars {
+    "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
+  }
 } 
 `
 }
@@ -189,7 +191,9 @@ resource "databricks_cluster" "cluster" {
   num_workers                   = 1
   autotermination_minutes       = 10
   permanently_delete            = true
-  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
+  spark_env_vars = {
+    "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
+  }
   aws_attributes = {
     instance_profile_arn = "AWSARNSTRING"
     zone_id              = "eu-west-1a"
@@ -213,7 +217,9 @@ resource "databricks_cluster" "cluster" {
   num_workers                   = 2
   autotermination_minutes       = 15
   permanently_delete            = true
-  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
+  spark_env_vars = {
+    "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
+  }
 } 
 `
 }
@@ -227,7 +233,9 @@ resource "databricks_cluster" "cluster" {
   num_workers                   = 2
   autotermination_minutes       = 15
   permanently_delete            = true
-  spark_env_vars.PYSPARK_PYTHON = "/databricks/python3/bin/python3"
+  spark_env_vars = {
+    "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
+  }
   aws_attributes = {
     instance_profile_arn = "AWSARNSTRING"
     zone_id              = "eu-west-1a"


### PR DESCRIPTION
This PR has multiple additions:

1.  Allow configuring of cluster spark environment variables, e.g.:

```
resource "databricks_cluster" "test-cluster" {
   name                    = "tf-test"
   spark_version           = "4.2.x-scala2.11"
   node_type_id            = "r3.xlarge"
   autotermination_minutes = 60

   spark_env_vars = {
     "PYSPARK_PYTHON" = "/databricks/python3/bin/python3"
     "example2" = "testing123"
   }
 }
```

2.  Add ability to run Acceptance Tests for AWS

By default, the provider is configured to perform tests for Azure.  When running this against AWS, we need to change the instance type, and also test the `aws_attributes`.  Depending on the setup, it may be required to assign an IAM Instance Profile ARN to the cluster instances.  We also need to specify the zone where the instance is to be located, as well as details relating to the volume.
This is done by setting the following option:
```
  aws_attributes = {
    instance_profile_arn = "AWSARNSTRING"
    zone_id              = "eu-west-1a"
    ebs_volume_type      = "THROUGHPUT_OPTIMIZED_HDD"
    ebs_volume_count     = 1
    ebs_volume_size      = 500
  }
```
To run the AWS Acceptance Tests, the environment variable `TEST_AWS` will need setting to 1, for example:
`$ export TEST_AWS 1`
To set the IAM Profile, then the following variable will also need to be set:
`$ export AWS_ARN_ROLE "arn:aws:iam::1234567890:instance-profile/example-databricks-worker-role"`

3.  Ensure we always send a complete JSON payload to the Databricks API when updating the cluster.

When performing interim updates to the cluster definition, we noticed that certain aspects of the cluster would either be lost, or overwritten by default values during the update.  Performing a manual request to the Databricks API itself outside of the provider, we were able to replicate this behaviour and subsequently raised a support ticket with them, who confirmed that there does appear to be an issue with the official documentation, and that a full JSON request will need to be sent for any update to an existing cluster.